### PR TITLE
[WIP] Laravel 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,9 +48,9 @@
     ],
     "require": {
         "php": "^7.4.0",
-        "illuminate/console": "^7.0.0",
-        "illuminate/database": "^7.0.0",
-        "illuminate/support": "^7.0.0",
+        "illuminate/console": "^7.0.0|^8.0.0",
+        "illuminate/database": "^7.0.0|^8.0.0",
+        "illuminate/support": "^7.0.0|^8.0.0",
         "jackpopp/geodistance": "^1.2.0",
         "rinvex/countries": "^7.0.0",
         "rinvex/laravel-support": "^4.0.0"


### PR DESCRIPTION
Currently blocked because of rinvex/laravel-support dependency that requires Laravel 8 support (https://github.com/rinvex/laravel-support/pull/38) as well.