### PR TITLE
Fix broken classpaths in version 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /build
 /vendor
 /node_modules

--- a/src/Events/AddressDeleted.php
+++ b/src/Events/AddressDeleted.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rinvex\Testimonials\Events;
+namespace Rinvex\Addresses\Events;
 
 use Illuminate\Broadcasting\Channel;
 use Rinvex\Addresses\Models\Address;

--- a/src/Events/AddressSaved.php
+++ b/src/Events/AddressSaved.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rinvex\Testimonials\Events;
+namespace Rinvex\Addresses\Events;
 
 use Illuminate\Broadcasting\Channel;
 use Rinvex\Addresses\Models\Address;

--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -9,8 +9,8 @@ use Rinvex\Cacheable\CacheableEloquent;
 use Illuminate\Database\Eloquent\Builder;
 use Jackpopp\GeoDistance\GeoDistanceTrait;
 use Rinvex\Support\Traits\ValidatingTrait;
-use Rinvex\Testimonials\Events\AddressSaved;
-use Rinvex\Testimonials\Events\AddressDeleted;
+use Rinvex\Addresses\Events\AddressSaved;
+use Rinvex\Addresses\Events\AddressDeleted;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 /**


### PR DESCRIPTION
Branched off from V3.0.2

Fixes bad classpath found in version 3 (Tag for LTS release of Laravel (6))

Class 'Rinvex\\Testimonials\\Events\\AddressSaved' not found Laravel 6

More here: https://www.gitmemory.com/issue/rinvex/laravel-addresses/29/597274749

