### PR TITLE
Set family name to nullable as it's not required in validation rules

### DIFF
--- a/database/migrations/2020_01_01_000002_alter_addresses_table_make_family_name_nullable.php
+++ b/database/migrations/2020_01_01_000002_alter_addresses_table_make_family_name_nullable.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateAddressesTable extends Migration
+class AlterAddressesTableMakeFamilyNameNullable extends Migration
 {
     public function up()
     {

--- a/database/migrations/2020_01_01_000002_set_family_name_nullable_in_addresses_table.php
+++ b/database/migrations/2020_01_01_000002_set_family_name_nullable_in_addresses_table.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateAddressesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table(config('rinvex.addresses.tables.addresses'), function (Blueprint $table) {
+            $table->string('family_name')->nullable()->change();
+        });
+    }
+}


### PR DESCRIPTION
Hello, 

I noticed that `family_name` column in `addresses` table is not required. But when I create a new address record with minimum requirements I got `Illuminate\Database\QueryException` exception because `family_name` doesn't have default value.

On my PR I created new migration to set `family_name` to nullable